### PR TITLE
fix: fix rabbitmq tracer cannot be concatenated, context error #18

### DIFF
--- a/broker/rabbitmq/rabbitmq.go
+++ b/broker/rabbitmq/rabbitmq.go
@@ -299,11 +299,11 @@ func (b *rabbitBroker) startProducerSpan(ctx context.Context, routingKey string,
 		trace.WithAttributes(attrs...),
 		trace.WithSpanKind(trace.SpanKindProducer),
 	}
-	ctx, span := b.opts.Tracer.Tracer.Start(ctx, "rabbitmq.produce", opts...)
+	newCtx, span := b.opts.Tracer.Tracer.Start(ctx, "rabbitmq.produce", opts...)
 
-	b.opts.Tracer.Propagators.Inject(ctx, carrier)
+	b.opts.Tracer.Propagators.Inject(newCtx, carrier)
 
-	return ctx, span
+	return newCtx, span
 }
 
 func (b *rabbitBroker) finishProducerSpan(ctx context.Context, span trace.Span, routingKey string, err error) {

--- a/broker/rabbitmq/rabbitmq.go
+++ b/broker/rabbitmq/rabbitmq.go
@@ -306,7 +306,7 @@ func (b *rabbitBroker) startProducerSpan(ctx context.Context, routingKey string,
 	return newCtx, span
 }
 
-func (b *rabbitBroker) finishProducerSpan(ctx context.Context, span trace.Span, routingKey string, err error) {
+func (b *rabbitBroker) finishProducerSpan(_ context.Context, span trace.Span, routingKey string, err error) {
 	if !span.IsRecording() {
 		return
 	}
@@ -354,7 +354,7 @@ func (b *rabbitBroker) startConsumerSpan(ctx context.Context, queueName string, 
 	return newCtx, span
 }
 
-func (b *rabbitBroker) finishConsumerSpan(ctx context.Context, span trace.Span, err error) {
+func (b *rabbitBroker) finishConsumerSpan(_ context.Context, span trace.Span, err error) {
 	if !span.IsRecording() {
 		return
 	}


### PR DESCRIPTION
`producer context` 使用错误，应该使用用户每次传递的 `context` ，而不是全局的 `context`
close #18 