### PR TITLE
fix: subscriber.ch isn't closed in the event of unexpected disconnection.

### DIFF
--- a/broker/rabbitmq/connection.go
+++ b/broker/rabbitmq/connection.go
@@ -169,6 +169,13 @@ func (r *rabbitConnection) reconnect(secure bool, config *amqp.Config) {
 			r.Unlock()
 		case err := <-notifyClose:
 			log.Error(err)
+
+			select {
+			case errs := <-chanNotifyClose:
+				log.Error(errs)
+			case <-time.After(time.Second):
+			}
+
 			r.Lock()
 			r.connected = false
 			r.waitConnection = make(chan struct{})


### PR DESCRIPTION
当 rabbitmq 发生故障重启，broker 自动重连时，consumer channel 不会自动关闭。相关 issue: https://github.com/tx7do/kratos-transport/issues/20