### PR TITLE
[fix]fix asynq issue #23 & #24

### DIFF
--- a/transport/asynq/server.go
+++ b/transport/asynq/server.go
@@ -178,11 +178,10 @@ func (s *Server) Stop(_ context.Context) error {
 }
 
 func (s *Server) init(opts ...ServerOption) {
-	_ = s.createAsynqServer()
-
 	for _, o := range opts {
 		o(s)
 	}
+	_ = s.createAsynqServer()
 }
 
 func (s *Server) createAsynqServer() error {
@@ -200,7 +199,7 @@ func (s *Server) createAsynqServer() error {
 }
 
 func (s *Server) runAsynqServer() error {
-	if s.asynqServer != nil {
+	if s.asynqServer == nil {
 		log.Errorf("[asynq] asynq server is nil")
 		return errors.New("asynq server is nil")
 	}
@@ -243,7 +242,7 @@ func (s *Server) createAsynqScheduler() error {
 }
 
 func (s *Server) runAsynqScheduler() error {
-	if s.asynqScheduler != nil {
+	if s.asynqScheduler == nil {
 		log.Errorf("[asynq] asynq scheduler is nil")
 		return errors.New("asynq scheduler is nil")
 	}


### PR DESCRIPTION
#23
 `runAsynqServer()`和`runAsynqScheduler()`校验`s.asynqServer` 和`s.asynqScheduler`是否为nil有误，应两者为nil时才返回error
#24 
创建`s.asynqServer`中没有传入`redisOpts`和`asynqConfig`，应先执行`opt(s)`再调用`s.createAsynqServer()`
close [#24 ](https://github.com/tx7do/kratos-transport/issues/24) && [#23 ](https://github.com/tx7do/kratos-transport/issues/23)