### PR TITLE
fix: 修复 `aliyunmq` 和 `rocketmq-client-go` 消息 handler error 的处理 

### DIFF
--- a/broker/rocketmq/aliyun/aliyunmq.go
+++ b/broker/rocketmq/aliyun/aliyunmq.go
@@ -289,6 +289,7 @@ func (r *aliyunmqBroker) doConsume(sub *Subscriber) {
 						err = sub.handler(ctx, p)
 						if err != nil {
 							LogErrorf("process message failed: %v", err)
+							return err
 						}
 
 						if sub.options.AutoAck {

--- a/broker/rocketmq/rocketmq-client-go/rocketmq.go
+++ b/broker/rocketmq/rocketmq-client-go/rocketmq.go
@@ -447,6 +447,7 @@ func (r *rocketmqBroker) Subscribe(topic string, handler broker.Handler, binder 
 				err = sub.handler(newCtx, p)
 				if err != nil {
 					r.logger.Errorf("process message failed: %v", err)
+					return consumer.ConsumeRetryLater, err
 				}
 				if sub.options.AutoAck {
 					if err = p.Ack(); err != nil {


### PR DESCRIPTION
#77 