### PR TITLE
kafka message add partition and offset

### DIFF
--- a/broker/kafka/kafka.go
+++ b/broker/kafka/kafka.go
@@ -623,8 +623,10 @@ func (b *kafkaBroker) Subscribe(topic string, handler broker.Handler, binder bro
 				ctx, span := b.startConsumerSpan(options.Context, &msg)
 
 				m := &broker.Message{
-					Headers: kafkaHeaderToMap(msg.Headers),
-					Body:    nil,
+					Headers:   kafkaHeaderToMap(msg.Headers),
+					Body:      nil,
+					Partition: msg.Partition,
+					Offset:    msg.Offset,
 				}
 
 				p := &publication{topic: msg.Topic, reader: sub.reader, m: m, km: msg, ctx: options.Context}

--- a/broker/message.go
+++ b/broker/message.go
@@ -7,8 +7,10 @@ type Binder func() Any
 type Headers map[string]string
 
 type Message struct {
-	Headers Headers
-	Body    Any
+	Headers   Headers
+	Body      Any
+	Partition int
+	Offset    int64
 }
 
 func (m Message) GetHeaders() Headers {


### PR DESCRIPTION
之所以添加分区和偏移量原因有两个

* 在大量消息的场景下程序处理错误 debug 会变的困难（消息没有必要全部打印）
* 分区和偏移量都是 `github.com/segmentio/kafka-go` FetchMessage 本身返回的我们不应该丢弃掉它