### PR TITLE
fix kafka subscriber EOF log when closing program

### DIFF
--- a/broker/kafka/kafka.go
+++ b/broker/kafka/kafka.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/gob"
 	"errors"
+	"io"
 	"strconv"
 	"sync"
 	"time"
@@ -613,6 +614,10 @@ func (b *kafkaBroker) Subscribe(topic string, handler broker.Handler, binder bro
 			default:
 				msg, err := sub.reader.FetchMessage(options.Context)
 				if err != nil {
+					if errors.Is(err, io.EOF) {
+						return
+					}
+
 					log.Errorf("[kafka] FetchMessage error: %s", err.Error())
 					continue
 				}


### PR DESCRIPTION
当 kafka consumer 程序关闭时会报大量的 EOF 日志，相关 issue：https://github.com/tx7do/kratos-transport/issues/69#issuecomment-1862662298

看了下 kafka-go v0.4.47 `Reader` 的 `FetchMessage()` 方法：
https://github.com/segmentio/kafka-go/blob/2af3101bdba0698ff97117cd2b0051510d996df7/reader.go#L833-L836
当 `r.msgs` 这个 channel 被 close，会返回 io.EOF

> close 的调用处见：https://github.com/segmentio/kafka-go/blob/2af3101bdba0698ff97117cd2b0051510d996df7/reader.go#L291-L292

而在本项目调用 `FetchMessage()`，只判断了 err != nil，然后 continue：
https://github.com/tx7do/kratos-transport/blob/da29a30232e7274f4a7943584a3ae0975e3ae07d/broker/kafka/kafka.go#L614-L618

结合 kafka-go 源码的返回，这里是不是可以加一个判断，当 err is io.EOF 时，说明 `r.msgs` 被 close 了，从而 return 退出循环。这样就不会报大量的 EOF 日志了。