### PR TITLE
fix(transport/machinery): ignore graceful exit error

### DIFF
--- a/transport/machinery/server.go
+++ b/transport/machinery/server.go
@@ -3,9 +3,10 @@ package machinery
 import (
 	"context"
 	"errors"
-	eagerBackend "github.com/RichardKnop/machinery/v2/backends/eager"
 	"net/url"
 	"sync"
+
+	eagerBackend "github.com/RichardKnop/machinery/v2/backends/eager"
 
 	"go.opentelemetry.io/otel/attribute"
 	semConv "go.opentelemetry.io/otel/semconv/v1.12.0"
@@ -185,7 +186,8 @@ func (s *Server) Start(ctx context.Context) error {
 		return nil
 	}
 
-	if err := s.newWorker(s.consumerOption.consumerTag, s.consumerOption.concurrency, s.consumerOption.queue); err != nil {
+	err := s.newWorker(s.consumerOption.consumerTag, s.consumerOption.concurrency, s.consumerOption.queue)
+	if err != nil && !errors.Is(err, machinery.ErrWorkerQuitGracefully) {
 		return err
 	}
 


### PR DESCRIPTION
Previously, the `(*Server).Start` function was returning all errors from `(*Server).newWorker`, including the `"Worker quit gracefully"` error. This change modifies the error handling to ignore the ErrWorkerQuitGracefully error, as a graceful exit should not be treated as an error condition.

- Only return errors that are not ErrWorkerQuitGracefully.
- Improve error handling logic in worker creation process.