### PR TITLE
fix nil pointer panic

### DIFF
--- a/keepalive/keepalive_test.go
+++ b/keepalive/keepalive_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestKeepAliveService(t *testing.T) {
-	svc := NewKeepAliveService(nil)
+	svc := NewKeepAliveService()
 	assert.NotNil(t, svc)
 	err := svc.Start()
 	assert.Nil(t, err)

--- a/transport/activemq/server.go
+++ b/transport/activemq/server.go
@@ -44,7 +44,7 @@ func NewServer(opts ...ServerOption) *Server {
 		subscriberOpts:  make(transport.SubscribeOptionMap),
 		brokerOpts:      []broker.Option{},
 		started:         atomic.Bool{},
-		keepAlive:       keepalive.NewKeepAliveService(nil),
+		keepAlive:       keepalive.NewKeepAliveService(),
 		enableKeepAlive: true,
 	}
 

--- a/transport/asynq/server.go
+++ b/transport/asynq/server.go
@@ -64,7 +64,7 @@ func NewServer(opts ...ServerOption) *Server {
 		schedulerOpts: &asynq.SchedulerOpts{},
 		mux:           asynq.NewServeMux(),
 
-		keepAlive:       keepalive.NewKeepAliveService(nil),
+		keepAlive:       keepalive.NewKeepAliveService(),
 		enableKeepAlive: true,
 
 		codec: encoding.GetCodec("json"),

--- a/transport/kafka/server.go
+++ b/transport/kafka/server.go
@@ -46,7 +46,7 @@ func NewServer(opts ...ServerOption) *Server {
 		subscriberOpts:  make(transport.SubscribeOptionMap),
 		brokerOpts:      []broker.Option{},
 		started:         atomic.Bool{},
-		keepAlive:       keepalive.NewKeepAliveService(nil),
+		keepAlive:       keepalive.NewKeepAliveService(),
 		enableKeepAlive: true,
 	}
 

--- a/transport/machinery/server.go
+++ b/transport/machinery/server.go
@@ -113,7 +113,7 @@ func NewServer(opts ...ServerOption) *Server {
 			retries:  1,
 		},
 
-		keepAlive:       keepalive.NewKeepAliveService(nil),
+		keepAlive:       keepalive.NewKeepAliveService(),
 		enableKeepAlive: true,
 	}
 

--- a/transport/mqtt/server.go
+++ b/transport/mqtt/server.go
@@ -44,7 +44,7 @@ func NewServer(opts ...ServerOption) *Server {
 		subscriberOpts:  make(transport.SubscribeOptionMap),
 		brokerOpts:      []broker.Option{},
 		started:         atomic.Bool{},
-		keepAlive:       keepalive.NewKeepAliveService(nil),
+		keepAlive:       keepalive.NewKeepAliveService(),
 		enableKeepAlive: true,
 	}
 

--- a/transport/nats/server.go
+++ b/transport/nats/server.go
@@ -44,7 +44,7 @@ func NewServer(opts ...ServerOption) *Server {
 		subscriberOpts:  make(transport.SubscribeOptionMap),
 		brokerOpts:      []broker.Option{},
 		started:         atomic.Bool{},
-		keepAlive:       keepalive.NewKeepAliveService(nil),
+		keepAlive:       keepalive.NewKeepAliveService(),
 		enableKeepAlive: true,
 	}
 

--- a/transport/nsq/server.go
+++ b/transport/nsq/server.go
@@ -44,7 +44,7 @@ func NewServer(opts ...ServerOption) *Server {
 		subscriberOpts:  make(transport.SubscribeOptionMap),
 		brokerOpts:      []broker.Option{},
 		started:         atomic.Bool{},
-		keepAlive:       keepalive.NewKeepAliveService(nil),
+		keepAlive:       keepalive.NewKeepAliveService(),
 		enableKeepAlive: true,
 	}
 

--- a/transport/pulsar/server.go
+++ b/transport/pulsar/server.go
@@ -44,7 +44,7 @@ func NewServer(opts ...ServerOption) *Server {
 		subscriberOpts:  make(transport.SubscribeOptionMap),
 		brokerOpts:      []broker.Option{},
 		started:         atomic.Bool{},
-		keepAlive:       keepalive.NewKeepAliveService(nil),
+		keepAlive:       keepalive.NewKeepAliveService(),
 		enableKeepAlive: true,
 	}
 

--- a/transport/rabbitmq/server.go
+++ b/transport/rabbitmq/server.go
@@ -44,7 +44,7 @@ func NewServer(opts ...ServerOption) *Server {
 		subscriberOpts:  make(transport.SubscribeOptionMap),
 		brokerOpts:      []broker.Option{},
 		started:         atomic.Bool{},
-		keepAlive:       keepalive.NewKeepAliveService(nil),
+		keepAlive:       keepalive.NewKeepAliveService(),
 		enableKeepAlive: true,
 	}
 

--- a/transport/redis/server.go
+++ b/transport/redis/server.go
@@ -48,7 +48,7 @@ func NewServer(opts ...ServerOption) *Server {
 		subscriberOpts:  make(transport.SubscribeOptionMap),
 		brokerOpts:      []broker.Option{},
 		started:         atomic.Bool{},
-		keepAlive:       keepalive.NewKeepAliveService(nil),
+		keepAlive:       keepalive.NewKeepAliveService(),
 		enableKeepAlive: true,
 	}
 

--- a/transport/rocketmq/server.go
+++ b/transport/rocketmq/server.go
@@ -46,7 +46,7 @@ func NewServer(driverType rocketmqOption.DriverType, opts ...ServerOption) *Serv
 		subscriberOpts:  make(transport.SubscribeOptionMap),
 		brokerOpts:      []broker.Option{},
 		started:         atomic.Bool{},
-		keepAlive:       keepalive.NewKeepAliveService(nil),
+		keepAlive:       keepalive.NewKeepAliveService(),
 		enableKeepAlive: true,
 	}
 


### PR DESCRIPTION
因 commit 66bc8cb  中 `keepalive` 的相关变更，`NewKeepAliveService` 的参数类型不一样了，导致初始化时出现空指针 panic。