### PR TITLE
修复了 kafka SubscribeOption 的读取问题

### DIFF
--- a/broker/kafka/kafka.go
+++ b/broker/kafka/kafka.go
@@ -590,67 +590,67 @@ func (b *kafkaBroker) Subscribe(
 		readerConfig.Dialer = kafkaGo.DefaultDialer
 	}
 
-	if value, ok := b.options.Context.Value(queueCapacityKey{}).(int); ok {
+	if value, ok := options.Context.Value(queueCapacityKey{}).(int); ok {
 		readerConfig.QueueCapacity = value
 	}
-	if value, ok := b.options.Context.Value(minBytesKey{}).(int); ok {
+	if value, ok := options.Context.Value(minBytesKey{}).(int); ok {
 		readerConfig.MinBytes = value
 	}
-	if value, ok := b.options.Context.Value(maxBytesKey{}).(int); ok {
+	if value, ok := options.Context.Value(maxBytesKey{}).(int); ok {
 		readerConfig.MaxBytes = value
 	}
-	if value, ok := b.options.Context.Value(maxWaitKey{}).(time.Duration); ok {
+	if value, ok := options.Context.Value(maxWaitKey{}).(time.Duration); ok {
 		readerConfig.MaxWait = value
 	}
-	if value, ok := b.options.Context.Value(readLagIntervalKey{}).(time.Duration); ok {
+	if value, ok := options.Context.Value(readLagIntervalKey{}).(time.Duration); ok {
 		readerConfig.ReadLagInterval = value
 	}
-	if value, ok := b.options.Context.Value(heartbeatIntervalKey{}).(time.Duration); ok {
+	if value, ok := GetHeartbeatInterval(b.options.Context); ok {
 		readerConfig.HeartbeatInterval = value
 	}
-	if value, ok := b.options.Context.Value(commitIntervalKey{}).(time.Duration); ok {
+	if value, ok := GetCommitInterval(b.options.Context); ok {
 		readerConfig.CommitInterval = value
 	}
-	if value, ok := b.options.Context.Value(partitionWatchIntervalKey{}).(time.Duration); ok {
+	if value, ok := GetPartitionWatchInterval(b.options.Context); ok {
 		readerConfig.PartitionWatchInterval = value
 	}
-	if value, ok := b.options.Context.Value(watchPartitionChangesKey{}).(bool); ok {
+	if value, ok := GetWatchPartitionChanges(b.options.Context); ok {
 		readerConfig.WatchPartitionChanges = value
 	}
-	if value, ok := b.options.Context.Value(sessionTimeoutKey{}).(time.Duration); ok {
+	if value, ok := options.Context.Value(sessionTimeoutKey{}).(time.Duration); ok {
 		readerConfig.SessionTimeout = value
 	}
-	if value, ok := b.options.Context.Value(rebalanceTimeoutKey{}).(time.Duration); ok {
+	if value, ok := options.Context.Value(rebalanceTimeoutKey{}).(time.Duration); ok {
 		readerConfig.RebalanceTimeout = value
 	}
-	if value, ok := b.options.Context.Value(retentionTimeKey{}).(time.Duration); ok {
+	if value, ok := options.Context.Value(retentionTimeKey{}).(time.Duration); ok {
 		readerConfig.RetentionTime = value
 	}
-	if value, ok := b.options.Context.Value(startOffsetKey{}).(int64); ok {
+	if value, ok := options.Context.Value(startOffsetKey{}).(int64); ok {
 		readerConfig.StartOffset = value
 	}
-	if value, ok := b.options.Context.Value(maxAttemptsKey{}).(int); ok {
+	if value, ok := options.Context.Value(maxAttemptsKey{}).(int); ok {
 		readerConfig.MaxAttempts = value
 	}
-	if value, ok := b.options.Context.Value(dialerConfigKey{}).(*kafkaGo.Dialer); ok {
+	if value, ok := options.Context.Value(dialerConfigKey{}).(*kafkaGo.Dialer); ok {
 		readerConfig.Dialer = value
 	}
-	if value, ok := b.options.Context.Value(dialerTimeoutKey{}).(time.Duration); ok {
+	if value, ok := options.Context.Value(dialerTimeoutKey{}).(time.Duration); ok {
 		if readerConfig.Dialer != nil {
 			readerConfig.Dialer.Timeout = value
 		}
 	}
 
-	if value, ok := b.options.Context.Value(partitionKey{}).(int); ok {
+	if value, ok := options.Context.Value(partitionKey{}).(int); ok {
 		readerConfig.Partition = value
 	}
-	if value, ok := b.options.Context.Value(readBatchTimeoutKey{}).(time.Duration); ok {
+	if value, ok := options.Context.Value(readBatchTimeoutKey{}).(time.Duration); ok {
 		readerConfig.ReadBatchTimeout = value
 	}
-	if value, ok := b.options.Context.Value(readBackoffMin{}).(time.Duration); ok {
+	if value, ok := options.Context.Value(readBackoffMin{}).(time.Duration); ok {
 		readerConfig.ReadBackoffMin = value
 	}
-	if value, ok := b.options.Context.Value(readBackoffMax{}).(time.Duration); ok {
+	if value, ok := options.Context.Value(readBackoffMax{}).(time.Duration); ok {
 		readerConfig.ReadBackoffMax = value
 	}
 

--- a/broker/kafka/kafka.go
+++ b/broker/kafka/kafka.go
@@ -580,8 +580,8 @@ func (b *kafkaBroker) Subscribe(
 
 	//LogInfof("topic: %s, group: %s, queue: %s", readerConfig.Topic, readerConfig.GroupID, options.Queue)
 
-	if value, ok := options.Context.Value(autoSubscribeCreateTopicKey{}).(*autoSubscribeCreateTopicValue); ok {
-		if err := CreateTopic(b.Address(), value.Topic, value.NumPartitions, value.ReplicationFactor); err != nil {
+	if topicName, numPartitions, replicationFactor, ok := GetSubscribeAutoCreateTopic(options.Context); ok {
+		if err := CreateTopic(b.Address(), topicName, numPartitions, replicationFactor); err != nil {
 			LogErrorf("create topic error: %s", err.Error())
 		}
 	}
@@ -590,67 +590,67 @@ func (b *kafkaBroker) Subscribe(
 		readerConfig.Dialer = kafkaGo.DefaultDialer
 	}
 
-	if value, ok := options.Context.Value(queueCapacityKey{}).(int); ok {
+	if value, ok := GetQueueCapacity(options.Context); ok {
 		readerConfig.QueueCapacity = value
 	}
-	if value, ok := options.Context.Value(minBytesKey{}).(int); ok {
+	if value, ok := GetMinBytes(options.Context); ok {
 		readerConfig.MinBytes = value
 	}
-	if value, ok := options.Context.Value(maxBytesKey{}).(int); ok {
+	if value, ok := GetMaxBytes(options.Context); ok {
 		readerConfig.MaxBytes = value
 	}
-	if value, ok := options.Context.Value(maxWaitKey{}).(time.Duration); ok {
+	if value, ok := GetMaxWait(options.Context); ok {
 		readerConfig.MaxWait = value
 	}
-	if value, ok := options.Context.Value(readLagIntervalKey{}).(time.Duration); ok {
+	if value, ok := GetReadLagInterval(options.Context); ok {
 		readerConfig.ReadLagInterval = value
 	}
-	if value, ok := GetHeartbeatInterval(b.options.Context); ok {
+	if value, ok := GetHeartbeatInterval(options.Context); ok {
 		readerConfig.HeartbeatInterval = value
 	}
-	if value, ok := GetCommitInterval(b.options.Context); ok {
+	if value, ok := GetCommitInterval(options.Context); ok {
 		readerConfig.CommitInterval = value
 	}
-	if value, ok := GetPartitionWatchInterval(b.options.Context); ok {
+	if value, ok := GetPartitionWatchInterval(options.Context); ok {
 		readerConfig.PartitionWatchInterval = value
 	}
-	if value, ok := GetWatchPartitionChanges(b.options.Context); ok {
+	if value, ok := GetWatchPartitionChanges(options.Context); ok {
 		readerConfig.WatchPartitionChanges = value
 	}
-	if value, ok := options.Context.Value(sessionTimeoutKey{}).(time.Duration); ok {
+	if value, ok := GetSessionTimeout(options.Context); ok {
 		readerConfig.SessionTimeout = value
 	}
-	if value, ok := options.Context.Value(rebalanceTimeoutKey{}).(time.Duration); ok {
+	if value, ok := GetRebalanceTimeout(options.Context); ok {
 		readerConfig.RebalanceTimeout = value
 	}
-	if value, ok := options.Context.Value(retentionTimeKey{}).(time.Duration); ok {
+	if value, ok := GetRetentionTime(options.Context); ok {
 		readerConfig.RetentionTime = value
 	}
-	if value, ok := options.Context.Value(startOffsetKey{}).(int64); ok {
+	if value, ok := GetStartOffset(options.Context); ok {
 		readerConfig.StartOffset = value
 	}
 	if value, ok := options.Context.Value(maxAttemptsKey{}).(int); ok {
 		readerConfig.MaxAttempts = value
 	}
-	if value, ok := options.Context.Value(dialerConfigKey{}).(*kafkaGo.Dialer); ok {
+	if value, ok := GetDialer(options.Context); ok {
 		readerConfig.Dialer = value
 	}
-	if value, ok := options.Context.Value(dialerTimeoutKey{}).(time.Duration); ok {
+	if value, ok := GetDialerTimeout(options.Context); ok {
 		if readerConfig.Dialer != nil {
 			readerConfig.Dialer.Timeout = value
 		}
 	}
 
-	if value, ok := options.Context.Value(partitionKey{}).(int); ok {
+	if value, ok := GetPartition(options.Context); ok {
 		readerConfig.Partition = value
 	}
-	if value, ok := options.Context.Value(readBatchTimeoutKey{}).(time.Duration); ok {
+	if value, ok := GetReadBatchTimeout(options.Context); ok {
 		readerConfig.ReadBatchTimeout = value
 	}
-	if value, ok := options.Context.Value(readBackoffMin{}).(time.Duration); ok {
+	if value, ok := GetReadBackoffMin(options.Context); ok {
 		readerConfig.ReadBackoffMin = value
 	}
-	if value, ok := options.Context.Value(readBackoffMax{}).(time.Duration); ok {
+	if value, ok := GetReadBackoffMax(options.Context); ok {
 		readerConfig.ReadBackoffMax = value
 	}
 
@@ -660,10 +660,10 @@ func (b *kafkaBroker) Subscribe(
 
 	sub := newSubscriber(b, topic, options, readerConfig, handler, binder)
 
-	if value, ok := options.Context.Value(subscribeBatchSizeKey{}).(int); ok {
+	if value, ok := GetSubscribeBatchSize(options.Context); ok {
 		sub.batchSize = value
 	}
-	if value, ok := options.Context.Value(subscribeBatchIntervalKey{}).(time.Duration); ok {
+	if value, ok := GetSubscribeBatchInterval(options.Context); ok {
 		sub.batchInterval = value
 	}
 

--- a/broker/kafka/options.go
+++ b/broker/kafka/options.go
@@ -287,9 +287,22 @@ func WithSubscribeAutoCreateTopic(topic string, numPartitions, replicationFactor
 	)
 }
 
+func GetSubscribeAutoCreateTopic(ctx context.Context) (string, int, int, bool) {
+	v, ok := ctx.Value(autoSubscribeCreateTopicKey{}).(*autoSubscribeCreateTopicValue)
+	if ok {
+		return v.Topic, v.NumPartitions, v.ReplicationFactor, true
+	}
+	return "", 0, 0, false
+}
+
 // WithDialerTimeout .
 func WithDialerTimeout(tm time.Duration) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(dialerTimeoutKey{}, tm)
+}
+
+func GetDialerTimeout(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(dialerTimeoutKey{}).(time.Duration)
+	return v, ok
 }
 
 // WithRetries 设置消息重发的次数
@@ -297,9 +310,19 @@ func WithRetries(cnt int) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(subscribeRetriesCountKey{}, cnt)
 }
 
+func GetRetries(ctx context.Context) (int, bool) {
+	v, ok := ctx.Value(subscribeRetriesCountKey{}).(int)
+	return v, ok
+}
+
 // WithQueueCapacity .
 func WithQueueCapacity(cap int) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(queueCapacityKey{}, cap)
+}
+
+func GetQueueCapacity(ctx context.Context) (int, bool) {
+	v, ok := ctx.Value(queueCapacityKey{}).(int)
+	return v, ok
 }
 
 // WithMinBytes fetch.min.bytes
@@ -307,9 +330,19 @@ func WithMinBytes(bytes int) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(minBytesKey{}, bytes)
 }
 
+func GetMinBytes(ctx context.Context) (int, bool) {
+	v, ok := ctx.Value(minBytesKey{}).(int)
+	return v, ok
+}
+
 // WithMaxBytes .
 func WithMaxBytes(bytes int) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(maxBytesKey{}, bytes)
+}
+
+func GetMaxBytes(ctx context.Context) (int, bool) {
+	v, ok := ctx.Value(maxBytesKey{}).(int)
+	return v, ok
 }
 
 // WithMaxWait fetch.max.wait.ms
@@ -317,9 +350,19 @@ func WithMaxWait(time time.Duration) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(maxWaitKey{}, time)
 }
 
+func GetMaxWait(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(maxWaitKey{}).(time.Duration)
+	return v, ok
+}
+
 // WithReadLagInterval .
 func WithReadLagInterval(interval time.Duration) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(readLagIntervalKey{}, interval)
+}
+
+func GetReadLagInterval(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(readLagIntervalKey{}).(time.Duration)
+	return v, ok
 }
 
 // WithHeartbeatInterval .
@@ -367,9 +410,19 @@ func WithSessionTimeout(timeout time.Duration) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(sessionTimeoutKey{}, timeout)
 }
 
+func GetSessionTimeout(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(sessionTimeoutKey{}).(time.Duration)
+	return v, ok
+}
+
 // WithRebalanceTimeout .
 func WithRebalanceTimeout(timeout time.Duration) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(rebalanceTimeoutKey{}, timeout)
+}
+
+func GetRebalanceTimeout(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(rebalanceTimeoutKey{}).(time.Duration)
+	return v, ok
 }
 
 // WithRetentionTime .
@@ -377,9 +430,19 @@ func WithRetentionTime(time time.Duration) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(retentionTimeKey{}, time)
 }
 
+func GetRetentionTime(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(retentionTimeKey{}).(time.Duration)
+	return v, ok
+}
+
 // WithStartOffset .
 func WithStartOffset(offset int64) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(startOffsetKey{}, offset)
+}
+
+func GetStartOffset(ctx context.Context) (int64, bool) {
+	v, ok := ctx.Value(startOffsetKey{}).(int64)
+	return v, ok
 }
 
 // WithDialer .
@@ -387,26 +450,61 @@ func WithDialer(cfg *kafkaGo.Dialer) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(dialerConfigKey{}, cfg)
 }
 
+func GetDialer(ctx context.Context) (*kafkaGo.Dialer, bool) {
+	v, ok := ctx.Value(dialerConfigKey{}).(*kafkaGo.Dialer)
+	return v, ok
+}
+
 func WithPartition(partition int) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(partitionKey{}, partition)
+}
+
+func GetPartition(ctx context.Context) (int, bool) {
+	v, ok := ctx.Value(partitionKey{}).(int)
+	return v, ok
 }
 
 func WithReadBatchTimeout(tm time.Duration) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(readBatchTimeoutKey{}, tm)
 }
 
+func GetReadBatchTimeout(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(readBatchTimeoutKey{}).(time.Duration)
+	return v, ok
+}
+
 func WithReadBackoffMin(tm time.Duration) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(readBackoffMin{}, tm)
+}
+
+func GetReadBackoffMin(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(readBackoffMin{}).(time.Duration)
+	return v, ok
 }
 
 func WithReadBackoffMax(tm time.Duration) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(readBackoffMax{}, tm)
 }
 
+func GetReadBackoffMax(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(readBackoffMax{}).(time.Duration)
+	return v, ok
+}
+
 func WithSubscribeBatchSize(batchSize int) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(subscribeBatchSizeKey{}, batchSize)
 }
 
+func GetSubscribeBatchSize(ctx context.Context) (int, bool) {
+	v, ok := ctx.Value(subscribeBatchSizeKey{}).(int)
+	return v, ok
+}
+
 func WithSubscribeBatchInterval(batchInterval time.Duration) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(subscribeBatchIntervalKey{}, batchInterval)
+}
+
+func GetSubscribeBatchInterval(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(subscribeBatchIntervalKey{}).(time.Duration)
+	return v, ok
 }

--- a/broker/kafka/options.go
+++ b/broker/kafka/options.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"context"
 	"hash"
 	"time"
 
@@ -326,9 +327,19 @@ func WithHeartbeatInterval(interval time.Duration) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(heartbeatIntervalKey{}, interval)
 }
 
+func GetHeartbeatInterval(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(heartbeatIntervalKey{}).(time.Duration)
+	return v, ok
+}
+
 // WithCommitInterval .
 func WithCommitInterval(interval time.Duration) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(commitIntervalKey{}, interval)
+}
+
+func GetCommitInterval(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(commitIntervalKey{}).(time.Duration)
+	return v, ok
 }
 
 // WithPartitionWatchInterval .
@@ -336,9 +347,19 @@ func WithPartitionWatchInterval(interval time.Duration) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(partitionWatchIntervalKey{}, interval)
 }
 
+func GetPartitionWatchInterval(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(partitionWatchIntervalKey{}).(time.Duration)
+	return v, ok
+}
+
 // WithWatchPartitionChanges .
 func WithWatchPartitionChanges(enable bool) broker.SubscribeOption {
 	return broker.SubscribeContextWithValue(watchPartitionChangesKey{}, enable)
+}
+
+func GetWatchPartitionChanges(ctx context.Context) (bool, bool) {
+	v, ok := ctx.Value(watchPartitionChangesKey{}).(bool)
+	return v, ok
 }
 
 // WithSessionTimeout .


### PR DESCRIPTION
原来的 SubscribeOption 只有设置值，并没有读取。读取的地方使用的是本地的 options。

导致 CommitInterval 等参数的设置不生效。